### PR TITLE
Add MiniMax LangChain model I/O example

### DIFF
--- a/案例与源码-2-LangChain框架/02-models_io/ModelIO_MiniMax.py
+++ b/案例与源码-2-LangChain框架/02-models_io/ModelIO_MiniMax.py
@@ -1,0 +1,22 @@
+"""Call MiniMax through LangChain's compatible chat model client."""
+
+import os
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+load_dotenv(encoding="utf-8")
+
+model = ChatOpenAI(
+    model="MiniMax-M3",
+    api_key=os.getenv("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",
+)
+
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain LangChain in one sentence."},
+]
+
+response = model.invoke(messages)
+print(response.content)


### PR DESCRIPTION
Reason: Add a MiniMax model I/O example to the LangChain tutorial.

- Add a runnable LangChain chat example configured for `MiniMax-M3`.
- Read `MINIMAX_API_KEY` from the environment and use `https://api.minimax.io/v1`.

Checks:
- `git diff --check`
- `python -m black --check --fast ModelIO_MiniMax.py`
- `python -m compileall -q ModelIO_MiniMax.py`
- Mocked example execution with assertions for the model and base URL.
