### PR TITLE
fix: 修复 README 中 Star History 图表失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=didilili/ai-agents-from-zero&type=date&legend=top-left)]()
+[![Star History Chart](https://star-history.dera.page/svg?repos=didilili/ai-agents-from-zero&type=date&legend=top-left)](https://star-history.dera.page/#didilili/ai-agents-from-zero&type=date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已无法正常展示，原因是原有图表服务受 GitHub 星标接口限制而失效。

本次修改将图表地址迁移到可正常工作的服务，并更新图片端点与点击后的跳转链接，让仓库的 Star 历史曲线能够正常显示。